### PR TITLE
Pluralize match error message

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -141,7 +141,7 @@ const scoresHelper = (isLive, team, body) => {
     if (live.length !== 0) {
       printScores(live, true);
     } else {
-      updateMessage('UPDATE', 'Sorry, no live match right now');
+      updateMessage('UPDATE', 'Sorry, no live matches right now');
     }
   } else {
     if (scores.length !== 0) {


### PR DESCRIPTION
Hi! Just a small PR for your consideration that pluralizes `match` in one of the error messages. The plural form sounds better (to me at least) and this keeps it consistent with other error messages e.g. `scores` here: https://github.com/ManrajGrover/football-cli/blob/b2135335aeb837775f88cfd5111e937a3ef5851a/helpers.js#L150

#### Before

```
$ football scores -l SA
Sorry, no live match right now
```

#### After

```
$ football scores -l SA
Sorry, no live matches right now
```

/cc @ManrajGrover ⚽️ 