### PR TITLE
Remove "-1" scores for future matches

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -77,8 +77,8 @@ const fixturesHelper = (league, name, team, body) => {
   for (let fixture of fixtures) {
     let homeTeam = fixture.homeTeamName;
     let awayTeam = fixture.awayTeamName;
-    let goalsHomeTeam = (fixture.result.goalsHomeTeam === null) ? '-1' : fixture.result.goalsHomeTeam;
-    let goalsAwayTeam = (fixture.result.goalsAwayTeam === null) ? '-1' : fixture.result.goalsAwayTeam;
+    let goalsHomeTeam = (fixture.result.goalsHomeTeam === null) ? '' : fixture.result.goalsHomeTeam;
+    let goalsAwayTeam = (fixture.result.goalsAwayTeam === null) ? '' : fixture.result.goalsAwayTeam;
 
     name = (league === undefined) ? getLeagueName(fixture) : name;
 


### PR DESCRIPTION
There should be no need to show a score for games that have not been played. This PR removes the "-1" default score for null goals when requesting for fixtures.

Thanks.